### PR TITLE
Refactor header with sticky navigation

### DIFF
--- a/frontend/src/components/Header/Header.jsx
+++ b/frontend/src/components/Header/Header.jsx
@@ -1,45 +1,141 @@
-import { NavLink } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, NavLink } from 'react-router-dom';
 import { useSiteContent } from '../../context/ContentContext.jsx';
 import styles from './Header.module.scss';
+
+const navItems = [
+  { to: '/', label: 'Home', end: true },
+  { to: '/about', label: 'About' },
+  { to: '/services', label: 'Services' },
+  { to: '/gallery', label: 'Gallery' },
+  { to: '/barbers', label: 'Barbers' },
+  { to: '/booking', label: 'Booking' },
+  { to: '/testimonials', label: 'Testimonials' },
+  { to: '/contact', label: 'Contact' }
+];
 
 const Header = () => {
   const { content } = useSiteContent();
   const business = content?.business || {};
+  const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
 
-  const getLinkClass = ({ isActive }) => (isActive ? styles.active : undefined);
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 8);
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = originalOverflow;
+    }
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open]);
+
+  const closeDrawer = () => setOpen(false);
+  const toggleDrawer = () => setOpen((value) => !value);
+  const headerClassName = scrolled
+    ? `${styles.header} ${styles.scrolled}`
+    : styles.header;
+  const drawerClassName = open
+    ? `${styles.drawer} ${styles.open}`
+    : styles.drawer;
+  const backdropClassName = open
+    ? `${styles.backdrop} ${styles.open}`
+    : styles.backdrop;
+  const burgerClassName = open
+    ? `${styles.burger} ${styles.open}`
+    : styles.burger;
+  const getLinkClass = ({ isActive }) =>
+    isActive ? `${styles.link} ${styles.linkActive}` : styles.link;
 
   return (
-    <header className={styles.header}>
-      <div className={styles.brand}>
-        <span className={styles.name}>{business.name}</span>
-        <span className={styles.tagline}>{business.location}</span>
+    <header className={headerClassName}>
+      <div className={styles.utility}>
+        <span>{business.location}</span>
       </div>
-      <nav className={styles.nav}>
-        <NavLink to="/" className={getLinkClass} end>
-          Home
-        </NavLink>
-        <NavLink to="/about" className={getLinkClass}>
-          About
-        </NavLink>
-        <NavLink to="/services" className={getLinkClass}>
-          Services
-        </NavLink>
-        <NavLink to="/gallery" className={getLinkClass}>
-          Gallery
-        </NavLink>
-        <NavLink to="/barbers" className={getLinkClass}>
-          Barbers
-        </NavLink>
-        <NavLink to="/booking" className={getLinkClass}>
-          Booking
-        </NavLink>
-        <NavLink to="/testimonials" className={getLinkClass}>
-          Testimonials
-        </NavLink>
-        <NavLink to="/contact" className={getLinkClass}>
-          Contact
-        </NavLink>
-      </nav>
+
+      <div className={styles.bar}>
+        <Link to="/" className={styles.logo} onClick={closeDrawer}>
+          <span className={styles.logoText}>{business.name}</span>
+        </Link>
+
+        <nav className={styles.nav} aria-label="Primary">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.end}
+              className={getLinkClass}
+              onClick={closeDrawer}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className={styles.cta}>
+          <Link to="/booking" className={styles.button} onClick={closeDrawer}>
+            Book Now
+          </Link>
+
+          <button
+            type="button"
+            className={burgerClassName}
+            aria-label="Toggle menu"
+            aria-expanded={open}
+            aria-controls="primary-drawer"
+            onClick={toggleDrawer}
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+        </div>
+      </div>
+
+      <div
+        id="primary-drawer"
+        className={drawerClassName}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className={styles.drawerInner}>
+          {navItems.map((item) => (
+            <NavLink
+              key={`${item.to}-mobile`}
+              to={item.to}
+              end={item.end}
+              className={getLinkClass}
+              onClick={closeDrawer}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+
+          <Link
+            to="/booking"
+            className={`${styles.button} ${styles.buttonBlock}`}
+            onClick={closeDrawer}
+          >
+            Book Now
+          </Link>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className={backdropClassName}
+        aria-label="Close menu"
+        onClick={closeDrawer}
+      />
     </header>
   );
 };

--- a/frontend/src/components/Header/Header.module.scss
+++ b/frontend/src/components/Header/Header.module.scss
@@ -1,60 +1,223 @@
+$bg: #0b0b0b;
+$bg-elev: rgba(10, 10, 10, 0.78);
+$fg: #f2f2f2;
+$muted: #a6a6a6;
+$gold: #c9a24a;
+
 .header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: $bg;
+  transition: background 0.2s ease, box-shadow 0.2s ease, backdrop-filter 0.2s ease;
+}
+
+.scrolled {
+  background: $bg-elev;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 2px 0 rgba(201, 162, 74, 0.15);
+}
+
+.utility {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  color: $muted;
+  border-bottom: 1px solid rgba(201, 162, 74, 0.15);
+}
+
+.bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  padding: 1.5rem 2rem;
-  background-color: rgba(10, 10, 10, 0.9);
-  border-bottom: 1px solid rgba(255, 215, 0, 0.2);
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  color: $fg;
 }
 
-.brand {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+.logo {
+  grid-column: 1 / 2;
+  text-decoration: none;
+
+  &:hover .logoText {
+    color: $gold;
+  }
 }
 
-.name {
-  font-size: 1.8rem;
-  font-weight: 600;
-  color: #f5d67b;
-  letter-spacing: 0.08em;
-}
-
-.tagline {
-  font-size: 0.85rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.7);
+.logoText {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  font-size: 1.25rem;
+  color: $fg;
 }
 
 .nav {
-  display: flex;
-  gap: 1.5rem;
-  font-size: 0.95rem;
-  flex-wrap: wrap;
-  justify-content: flex-end;
+  grid-column: 2 / 3;
+  display: none;
+  gap: 1.125rem;
+
+  @media (min-width: 1024px) {
+    display: flex;
+  }
 }
 
-.nav a {
-  color: rgba(255, 255, 255, 0.8);
-  font-weight: 500;
-  letter-spacing: 0.05em;
+.link {
+  position: relative;
+  text-decoration: none;
+  color: $fg;
+  font-size: 0.875rem;
   text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: $gold;
+  }
 }
 
-.active {
-  color: #f5d67b !important;
+.linkActive {
+  color: $gold;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -0.375rem;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, $gold, transparent);
+  }
 }
 
-@media (max-width: 900px) {
-  .header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1.5rem;
+.cta {
+  grid-column: 3 / 4;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.button {
+  padding: 0.625rem 0.875rem;
+  border: 1px solid rgba(201, 162, 74, 0.55);
+  color: $gold;
+  background: transparent;
+  border-radius: 0.375rem;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  transition: transform 0.1s ease, background 0.2s ease, color 0.2s ease;
+
+  &:hover {
+    background: rgba(201, 162, 74, 0.12);
   }
 
-  .nav {
-    justify-content: flex-start;
-    gap: 1rem;
+  &:active {
+    transform: translateY(1px);
+  }
+}
+
+.buttonBlock {
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
+.burger {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  background: transparent;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: rgba(201, 162, 74, 0.55);
+  }
+
+  span {
+    height: 2px;
+    width: 1.125rem;
+    background: $fg;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 1024px) {
+    display: none;
+  }
+}
+
+.open {
+  &.burger {
+    span:nth-child(1) {
+      transform: translateY(0.375rem) rotate(45deg);
+    }
+
+    span:nth-child(2) {
+      opacity: 0;
+    }
+
+    span:nth-child(3) {
+      transform: translateY(-0.375rem) rotate(-45deg);
+    }
+  }
+
+  &.drawer {
+    transform: translateX(0);
+  }
+
+  &.backdrop {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.drawer {
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: 84%;
+  max-width: 22.5rem;
+  background: #0f0f0f;
+  transform: translateX(100%);
+  transition: transform 0.2s ease;
+  z-index: 1001;
+  padding-top: 0.75rem;
+}
+
+.drawerInner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.125rem 1rem 1.5rem;
+
+  .link {
+    font-size: 1rem;
+  }
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 1000;
+}
+
+@media (min-width: 1024px) {
+  .bar {
+    padding: 1rem 1.75rem;
+  }
+
+  .button {
+    padding: 0.625rem 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the header to include sticky styling, scroll blur, and responsive navigation drawer
- add persistent booking call-to-action with desktop and mobile presentation updates

## Testing
- npm test --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e06e32e900833099c724e1bb0f2c06